### PR TITLE
Notify the delegate of events after updating our internal state

### DIFF
--- a/TRVSEventSource/TRVSEventSource.m
+++ b/TRVSEventSource/TRVSEventSource.m
@@ -95,11 +95,11 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
         strongSelf.URLSessionTask = [strongSelf.URLSession dataTaskWithURL:strongSelf.URL];
         [strongSelf.URLSessionTask resume];
         
+        strongSelf.state = TRVSEventSourceOpen;
+
         if ([strongSelf.delegate respondsToSelector:@selector(eventSourceDidOpen:)]) {
             [strongSelf.delegate eventSourceDidOpen:strongSelf];
         }
-        
-        strongSelf.state = TRVSEventSourceOpen;
     });
     
     return YES;
@@ -115,8 +115,12 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
         strongSelf.outputStream.delegate = nil;
         [strongSelf.outputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
         [strongSelf.outputStream close];
-        if ([strongSelf.delegate respondsToSelector:@selector(eventSourceDidClose:)]) [strongSelf.delegate eventSourceDidClose:strongSelf];
+
         strongSelf.state = TRVSEventSourceClosed;
+
+        if ([strongSelf.delegate respondsToSelector:@selector(eventSourceDidClose:)]) {
+            [strongSelf.delegate eventSourceDidClose:strongSelf];
+        }
     });
     
     return YES;


### PR DESCRIPTION
Updates the open and close methods to notify the delegate last, after they've updated the current state.

Should the delegate decide to inspect the given EventSource, its state should be consistent. Otherwise, the following assertion would fail:

``` objc
- (void)eventSourceDidClose:(TRVSEventSource *)eventSource {
    NSAssert(eventSource.isClosed, @"Event source should be closed");
}
```
