### PR TITLE
Add Ability to Configure Session

### DIFF
--- a/TRVSEventSource/TRVSEventSource.h
+++ b/TRVSEventSource/TRVSEventSource.h
@@ -54,6 +54,17 @@ typedef void (^TRVSEventSourceEventHandler)(TRVSServerSentEvent *event, NSError 
  */
 - (instancetype)initWithURL:(NSURL *)URL;
 
+/**
+ *  Initializes an `TRVSEventSource` object with the specified URL and session configuration. The event source will open only by calling -[TRVSEventSource open].
+ *
+ *  @param URL The url the event source will receive events from.
+ *
+ *  @param sessionConfiguration The session configuration that will be used to initialize the session object.
+ *
+ *  @return The newly-initialized event source.
+ */
+- (instancetype)initWithURL:(NSURL *)URL sessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
+
 // @name opening and closing an event source
 
 /**

--- a/TRVSEventSource/TRVSEventSource.m
+++ b/TRVSEventSource/TRVSEventSource.m
@@ -65,15 +65,20 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
 @implementation TRVSEventSource
 
 - (instancetype)initWithURL:(NSURL *)URL {
-    if (!(self = [super init])) return nil;
+    return [self initWithURL:URL sessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+}
 
+- (instancetype)initWithURL:(NSURL *)URL sessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration {
+    if (!sessionConfiguration) return nil;
+    if (!(self = [super init])) return nil;
+    
     self.operationQueue = [[NSOperationQueue alloc] init];
     self.operationQueue.name = TRVSEventSourceOperationQueueName;
     self.URL = URL;
     self.listenersKeyedByEvent = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsCopyIn valueOptions:NSPointerFunctionsStrongMemory capacity:TRVSEventSourceListenersCapacity];
-    self.URLSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:self.operationQueue];
+    self.URLSession = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:self.operationQueue];
     self.syncQueue = dispatch_queue_create(TRVSEventSourceSyncQueueLabel, NULL);
-
+    
     return self;
 }
 


### PR DESCRIPTION
Add the ability to configure the session object by passing a session configuration object during initialization. To accomplish this, `initWithURL:sessionConfiguration:` is available in the `TRVSEventSource` class.
