### PR TITLE
Synchronize write on string buffer

### DIFF
--- a/TRVSEventSource/TRVSEventSource.m
+++ b/TRVSEventSource/TRVSEventSource.m
@@ -271,7 +271,7 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
 
 - (void)transitionToConnecting {
   self.state = TRVSEventSourceConnecting;
-  [_operationQueue addOperationWithBlock:^{
+  [self.operationQueue addOperationWithBlock:^{
     [self.buffer setString:@""];
   }];
   self.URLSessionTask = [self.URLSession dataTaskWithURL:self.URL];
@@ -280,7 +280,7 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
 
 - (void)transitionToClosing {
   self.state = TRVSEventSourceClosing;
-  [_operationQueue addOperationWithBlock:^{
+  [self.operationQueue addOperationWithBlock:^{
     [self.buffer setString:@""];
   }];
   [self.URLSession invalidateAndCancel];

--- a/TRVSEventSource/TRVSEventSource.m
+++ b/TRVSEventSource/TRVSEventSource.m
@@ -84,6 +84,7 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
 
   _operationQueue = [[NSOperationQueue alloc] init];
   _operationQueue.name = TRVSEventSourceOperationQueueName;
+  _operationQueue.maxConcurrentOperationCount = 1;
   _URL = URL;
   _listenersKeyedByEvent =
       [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsCopyIn
@@ -270,14 +271,18 @@ typedef NS_ENUM(NSUInteger, TRVSEventSourceState) {
 
 - (void)transitionToConnecting {
   self.state = TRVSEventSourceConnecting;
-  [self.buffer setString:@""];
+  [_operationQueue addOperationWithBlock:^{
+    [self.buffer setString:@""];
+  }];
   self.URLSessionTask = [self.URLSession dataTaskWithURL:self.URL];
   [self.URLSessionTask resume];
 }
 
 - (void)transitionToClosing {
   self.state = TRVSEventSourceClosing;
-  [self.buffer setString:@""];
+  [_operationQueue addOperationWithBlock:^{
+    [self.buffer setString:@""];
+  }];
   [self.URLSession invalidateAndCancel];
 }
 


### PR DESCRIPTION
Write on string buffer should be synchronized on serial operation queue. Otherwise it is causing range out of bound inside

> - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data;